### PR TITLE
fix: add async/await to babel suite

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -21,8 +21,8 @@ b.suite(
     })
   }),
 
-  b.add('babel', () => {
-    babelTransform(code, {
+  b.add('babel', async () => {
+    await babelTransform(code, {
       plugins: ['@vue/babel-plugin-jsx'],
     })
   }),


### PR DESCRIPTION
### Description

The babel suite doesn't have `async/await`, causing the `babel.transform` promise to be floated. This results in the babel suite won't have to wait for the promise to be resolved before the next cycle begins. The PR fixes that.

Please do note you would have to update your benchmark result in the README after the PR is merged.
